### PR TITLE
Revert "fix: Get correct ID in getTransactionReference function"

### DIFF
--- a/src/Message/ChargeResponse.php
+++ b/src/Message/ChargeResponse.php
@@ -78,7 +78,7 @@ class ChargeResponse extends AbstractResponse implements RedirectResponseInterfa
      */
     public function getTransactionReference()
     {
-        return $this->getOrderId();
+        return $this->getTransactionId();
     }
 
     /**


### PR DESCRIPTION
This reverts commit 3b368d18260ea9fb31d57ddf2e6aeb89a41c269b.

Reverting this because the transaction ID is required for refunding
payments.  The order ID should be obtained through a different function.