### PR TITLE
Fix exception if refund status is an error

### DIFF
--- a/src/Message/RefundResponse.php
+++ b/src/Message/RefundResponse.php
@@ -22,7 +22,7 @@ class RefundResponse extends AbstractResponse
     
     public function getTransactionReference()
     {
-        return $this->data['id'];
+        return $this->isSuccessful() || $this->isPending() ? $this->data['id'] : null;
     }
 
     public function getMessage()


### PR DESCRIPTION
Sorry I missed this when I submitted my last PR (#16). If the refund results in an error then the 'id' key doesn't exist.

Can solve this a few ways, but AFAIK it should always be present if it's successful or pending?